### PR TITLE
fix: rf-deps command does not install dependencies

### DIFF
--- a/redfish/openapi/infra/Makefile
+++ b/redfish/openapi/infra/Makefile
@@ -90,7 +90,7 @@ $(GENERATED_SERVER): $(MERGED_OPENAPI)
 	oapi-codegen -generate gin,strict-server -o $(GENERATED_SERVER) -package generated $(MERGED_OPENAPI)
 	@echo "✅ Generated server code: $(GENERATED_SERVER)"
 
-rf-deps: rf-check-tools ### Install dependencies and required tools for Redfish API
+rf-deps: ### Install dependencies and required tools for Redfish API
 	$(call check_ubuntu)
 	@echo "🔧 Installing and verifying all dependencies..."
 	@$(MAKE) rf-install-missing-tools


### PR DESCRIPTION
On my system, I hadn't ran these commands yet.  I was missing two dependencies, but they wouldn't install, it ran the dependency checker.  Found there was a command to run the tracker at the top of the script, which I'm assuming was an error.