### PR TITLE
fix: handle nullable password fields in database operations

### DIFF
--- a/internal/usecase/devices/repo.go
+++ b/internal/usecase/devices/repo.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/device-management-toolkit/console/internal/entity"
 	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
 	"github.com/device-management-toolkit/console/internal/usecase/sqldb"
 	"github.com/device-management-toolkit/console/pkg/consoleerrors"
@@ -74,23 +75,38 @@ func (uc *UseCase) GetByID(ctx context.Context, guid, tenantID string, includeSe
 
 	d2 := uc.entityToDTO(data)
 	if includeSecrets {
-		d2.Password, err = uc.safeRequirements.Decrypt(data.Password)
+		err = uc.decryptPasswords(data, d2)
 		if err != nil {
-			return nil, ErrDeviceUseCase.Wrap("GetByID", "uc.safeRequirements.Decrypt Password", err)
-		}
-
-		d2.MPSPassword, err = uc.safeRequirements.Decrypt(data.MPSPassword)
-		if err != nil {
-			return nil, ErrDeviceUseCase.Wrap("GetByID", "uc.safeRequirements.Decrypt MPSPassword", err)
-		}
-
-		d2.MEBXPassword, err = uc.safeRequirements.Decrypt(data.MEBXPassword)
-		if err != nil {
-			return nil, ErrDeviceUseCase.Wrap("GetByID", "uc.safeRequirements.Decrypt MEBXPassword", err)
+			return nil, err
 		}
 	}
 
 	return d2, nil
+}
+
+func (uc *UseCase) decryptPasswords(data *entity.Device, d2 *dto.Device) error {
+	var err error
+
+	d2.Password, err = uc.safeRequirements.Decrypt(data.Password)
+	if err != nil {
+		return ErrDeviceUseCase.Wrap("GetByID", "uc.safeRequirements.Decrypt Password", err)
+	}
+
+	if data.MPSPassword != "" {
+		d2.MPSPassword, err = uc.safeRequirements.Decrypt(data.MPSPassword)
+		if err != nil {
+			return ErrDeviceUseCase.Wrap("GetByID", "uc.safeRequirements.Decrypt MPSPassword", err)
+		}
+	}
+
+	if data.MEBXPassword != "" {
+		d2.MEBXPassword, err = uc.safeRequirements.Decrypt(data.MEBXPassword)
+		if err != nil {
+			return ErrDeviceUseCase.Wrap("GetByID", "uc.safeRequirements.Decrypt MEBXPassword", err)
+		}
+	}
+
+	return nil
 }
 
 func (uc *UseCase) GetDistinctTags(ctx context.Context, tenantID string) ([]string, error) {

--- a/internal/usecase/profiles/usecase.go
+++ b/internal/usecase/profiles/usecase.go
@@ -174,9 +174,11 @@ func (uc *UseCase) DecryptPasswords(data *entity.Profile) error {
 		return err
 	}
 
-	data.MEBXPassword, err = uc.safeRequirements.Decrypt(data.MEBXPassword)
-	if err != nil {
-		return err
+	if data.MEBXPassword != "" {
+		data.MEBXPassword, err = uc.safeRequirements.Decrypt(data.MEBXPassword)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/usecase/sqldb/device.go
+++ b/internal/usecase/sqldb/device.go
@@ -168,9 +168,20 @@ func (r *DeviceRepo) GetByID(_ context.Context, guid, tenantID string) (*entity.
 	for rows.Next() {
 		d := &entity.Device{}
 
-		err = rows.Scan(&d.GUID, &d.Hostname, &d.Tags, &d.MPSInstance, &d.ConnectionStatus, &d.MPSUsername, &d.TenantID, &d.FriendlyName, &d.DNSSuffix, &d.DeviceInfo, &d.Username, &d.Password, &d.MPSPassword, &d.MEBXPassword, &d.UseTLS, &d.AllowSelfSigned, &d.CertHash)
+		var mpsPassword, mebxPassword sql.NullString
+
+		err = rows.Scan(&d.GUID, &d.Hostname, &d.Tags, &d.MPSInstance, &d.ConnectionStatus, &d.MPSUsername, &d.TenantID, &d.FriendlyName, &d.DNSSuffix, &d.DeviceInfo, &d.Username, &d.Password, &mpsPassword, &mebxPassword, &d.UseTLS, &d.AllowSelfSigned, &d.CertHash)
 		if err != nil {
 			return d, ErrDeviceDatabase.Wrap("Get", "rows.Scan: ", err)
+		}
+
+		// Handle nullable fields
+		if mpsPassword.Valid {
+			d.MPSPassword = mpsPassword.String
+		}
+
+		if mebxPassword.Valid {
+			d.MEBXPassword = mebxPassword.String
 		}
 
 		devices = append(devices, d)


### PR DESCRIPTION
- Add null checks before decrypting optional password fields MPSPassword, MEBXPassword.
- Use sql.NullString for proper database null value handling in device queries